### PR TITLE
lang/rust: Change cargo flag

### DIFF
--- a/Makefile.uk
+++ b/Makefile.uk
@@ -36,7 +36,7 @@
 $(eval $(call addlib_s,libukcargo,$(CONFIG_LIBUKCARGO)))
 
 CARGOFLAGS-y	+= -Cpanic=abort -Cembed-bitcode=n \
-		-Zbinary_dep_depinfo=y -Zsymbol-mangling-version=v0 \
+		-Zbinary_dep_depinfo=y -Csymbol-mangling-version=v0 \
 		-Cforce-unwind-tables=n -Ccodegen-units=1 \
 		-Dunsafe_op_in_unsafe_fn -Drust_2018_idioms
 


### PR DESCRIPTION
Change the cargo flag from `-Z` to `-C` because
the option `symbol-mangling-version` is stable in
`rustc 1.68.0-nightly (388538fc9 2023-01-05)`.

This removes a warning.

Signed-off-by: Fabian Patras <patras.fabi@gmail.com>